### PR TITLE
Build with no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
+#![cfg_attr(not(test), no_std)]
+
+#[cfg(test)]
+extern crate core;
 
 pub mod sip;
 pub mod sip128;

--- a/src/sip.rs
+++ b/src/sip.rs
@@ -10,12 +10,12 @@
 
 //! An implementation of SipHash.
 
-use std::cmp;
-use std::hash;
-use std::marker::PhantomData;
-use std::mem;
-use std::ptr;
-use std::slice;
+use core::cmp;
+use core::hash;
+use core::marker::PhantomData;
+use core::mem;
+use core::ptr;
+use core::slice;
 
 /// An implementation of SipHash 1-3.
 ///

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -10,12 +10,12 @@
 
 //! An implementation of SipHash with a 128-bit output.
 
-use std::cmp;
-use std::hash;
-use std::marker::PhantomData;
-use std::mem;
-use std::ptr;
-use std::slice;
+use core::cmp;
+use core::hash;
+use core::marker::PhantomData;
+use core::mem;
+use core::ptr;
+use core::slice;
 
 /// A 128-bit (2x64) hash output
 #[derive(Debug, Clone, Copy, Default)]
@@ -450,8 +450,8 @@ impl Sip for Sip24Rounds {
 
 impl Hash128 {
     /// Convert into a 16-bytes vector
-    pub fn into_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![0u8; 16];
+    pub fn into_bytes(&self) -> [u8; 16] {
+        let mut bytes = [0u8; 16];
         let h1 = self.h1.to_le();
         let h2 = self.h2.to_le();
         unsafe {

--- a/src/tests128.rs
+++ b/src/tests128.rs
@@ -45,7 +45,7 @@ macro_rules! u8to64_le {
     });
 }
 
-fn hash_with<H: Hasher + Hasher128, T: Hash>(mut st: H, x: &T) -> Vec<u8> {
+fn hash_with<H: Hasher + Hasher128, T: Hash>(mut st: H, x: &T) -> [u8; 16] {
     x.hash(&mut st);
     st.finish128().into_bytes()
 }


### PR DESCRIPTION
There is a breaking change to `Hash128` unfortunately, but avoiding the allocation there seems beneficial anyway.