### PR TITLE
Update version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In `Cargo.toml`:
 
 ```toml
 [dependencies]
-siphasher = "~0.1"
+siphasher = "~0.2"
 ```
 
 64-bit mode:


### PR DESCRIPTION
The current version is 0.2.2, however the snippet in the README constrains the version to 0.1.x.