### PR TITLE
Add finish_buf output function for 128-bit hasher

### DIFF
--- a/src/tests128.rs
+++ b/src/tests128.rs
@@ -61,6 +61,7 @@ fn test_siphash128_1_3() {
     let k0 = 0x_07_06_05_04_03_02_01_00;
     let k1 = 0x_0f_0e_0d_0c_0b_0a_09_08;
     let mut buf = Vec::new();
+    let mut out_buf = [0u8; 16];
     let mut t = 0;
     let mut state_inc = SipHasher13::new_with_keys(k0, k1);
 
@@ -71,8 +72,10 @@ fn test_siphash128_1_3() {
 
         let full = hash_with(SipHasher13::new_with_keys(k0, k1), &Bytes(&buf));
         let i = state_inc.finish128().as_bytes();
+        state_inc.finish_buf(&mut out_buf);
 
         assert_eq!(full, i);
+        assert_eq!(full, out_buf[..]);
         assert_eq!(full, vec);
 
         buf.push(t as u8);
@@ -94,6 +97,7 @@ fn test_siphash128_2_4() {
     let k0 = 0x_07_06_05_04_03_02_01_00;
     let k1 = 0x_0f_0e_0d_0c_0b_0a_09_08;
     let mut buf = Vec::new();
+    let mut out_buf = [0u8; 32];    // deliberately use longer output buffer
     let mut t = 0;
     let mut state_inc = SipHasher24::new_with_keys(k0, k1);
 
@@ -104,8 +108,11 @@ fn test_siphash128_2_4() {
 
         let full = hash_with(SipHasher24::new_with_keys(k0, k1), &Bytes(&buf));
         let i = state_inc.finish128().as_bytes();
+        state_inc.finish_buf(&mut out_buf);
 
         assert_eq!(full, i);
+        assert_eq!(full, out_buf[0..16]);
+        assert!(full != out_buf[16..32]);
         assert_eq!(full, vec);
 
         buf.push(t as u8);


### PR DESCRIPTION
This is a proof of concept.

The idea is to make it easy to reproducibly seed any PRNG (see [`Seed` type](https://docs.rs/rand_core/0.2.1/rand_core/trait.SeedableRng.html#associatedtype.Seed)) from any input with a "good quality" seed.

To make it portable it also needs `Hasher` to be portable [see this thread](https://internals.rust-lang.org/t/make-hasher-portable-mini-rfc/7927/5).

It's not intended for cryptography (and definitely not for password hashing).