### PR TITLE
Optional serde support and PartialEq deriving

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,16 @@ travis-ci = { repository = "jedisct1/rust-siphash" }
 lto = true
 panic = "abort"
 opt-level = 3
+
+[dependencies]
+serde = { version = "1.0.104", features = ["derive"], optional = true }
+
+[dev-dependencies]
+serde_json = "1.0"
+
+
+[features]
+default = ["std"]
+serde_std = ["std", "serde/std"]
+serde_no_std = ["serde/alloc"]
+std = []

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ In `Cargo.toml`:
 siphasher = "0.3"
 ```
 
+If you want [serde](https://github.com/serde-rs/serde) support, include the feature like this:
+
+```toml
+[dependencies]
+siphasher = { version = "0.3", features = ["serde"] }
+```
+
 64-bit mode:
 ```rust
 extern crate siphasher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(test), no_std)]
-
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::cast_lossless)]
 

--- a/src/sip.rs
+++ b/src/sip.rs
@@ -21,6 +21,7 @@ use core::slice;
 ///
 /// See: <https://131002.net/siphash/>
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher13 {
     hasher: Hasher<Sip13Rounds>,
 }
@@ -29,6 +30,7 @@ pub struct SipHasher13 {
 ///
 /// See: <https://131002.net/siphash/>
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher24 {
     hasher: Hasher<Sip24Rounds>,
 }
@@ -46,9 +48,11 @@ pub struct SipHasher24 {
 /// it is not intended for cryptographic purposes. As such, all
 /// cryptographic uses of this implementation are _strongly discouraged_.
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher(SipHasher24);
 
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct Hasher<S: Sip> {
     k0: u64,
     k1: u64,
@@ -60,6 +64,7 @@ struct Hasher<S: Sip> {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct State {
     // v0, v2 and v1, v3 show up in pairs in the algorithm,
     // and simd implementations of SipHash will use vectors

--- a/src/sip.rs
+++ b/src/sip.rs
@@ -20,7 +20,7 @@ use core::slice;
 /// An implementation of SipHash 1-3.
 ///
 /// See: <https://131002.net/siphash/>
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher13 {
     hasher: Hasher<Sip13Rounds>,
@@ -29,7 +29,7 @@ pub struct SipHasher13 {
 /// An implementation of SipHash 2-4.
 ///
 /// See: <https://131002.net/siphash/>
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher24 {
     hasher: Hasher<Sip24Rounds>,
@@ -47,11 +47,11 @@ pub struct SipHasher24 {
 /// Although the SipHash algorithm is considered to be generally strong,
 /// it is not intended for cryptographic purposes. As such, all
 /// cryptographic uses of this implementation are _strongly discouraged_.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher(SipHasher24);
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct Hasher<S: Sip> {
     k0: u64,
@@ -63,7 +63,7 @@ struct Hasher<S: Sip> {
     _marker: PhantomData<S>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct State {
     // v0, v2 and v1, v3 show up in pairs in the algorithm,
@@ -387,7 +387,7 @@ trait Sip {
     fn d_rounds(_: &mut State);
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 struct Sip13Rounds;
 
 impl Sip for Sip13Rounds {
@@ -404,7 +404,7 @@ impl Sip for Sip13Rounds {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 struct Sip24Rounds;
 
 impl Sip for Sip24Rounds {

--- a/src/sip.rs
+++ b/src/sip.rs
@@ -20,7 +20,7 @@ use core::slice;
 /// An implementation of SipHash 1-3.
 ///
 /// See: <https://131002.net/siphash/>
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher13 {
     hasher: Hasher<Sip13Rounds>,
@@ -29,7 +29,7 @@ pub struct SipHasher13 {
 /// An implementation of SipHash 2-4.
 ///
 /// See: <https://131002.net/siphash/>
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher24 {
     hasher: Hasher<Sip24Rounds>,
@@ -47,11 +47,11 @@ pub struct SipHasher24 {
 /// Although the SipHash algorithm is considered to be generally strong,
 /// it is not intended for cryptographic purposes. As such, all
 /// cryptographic uses of this implementation are _strongly discouraged_.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher(SipHasher24);
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct Hasher<S: Sip> {
     k0: u64,
@@ -63,7 +63,7 @@ struct Hasher<S: Sip> {
     _marker: PhantomData<S>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct State {
     // v0, v2 and v1, v3 show up in pairs in the algorithm,
@@ -387,7 +387,7 @@ trait Sip {
     fn d_rounds(_: &mut State);
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default)]
 struct Sip13Rounds;
 
 impl Sip for Sip13Rounds {
@@ -404,7 +404,7 @@ impl Sip for Sip13Rounds {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default)]
 struct Sip24Rounds;
 
 impl Sip for Sip24Rounds {

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -18,7 +18,7 @@ use core::ptr;
 use core::slice;
 
 /// A 128-bit (2x64) hash output
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Hash128 {
     pub h1: u64,
@@ -41,14 +41,14 @@ impl Into<u128> for Hash128 {
 }
 
 /// An implementation of SipHash128 1-3.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher13 {
     hasher: Hasher<Sip13Rounds>,
 }
 
 /// An implementation of SipHash128 2-4.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher24 {
     hasher: Hasher<Sip24Rounds>,
@@ -64,10 +64,10 @@ pub struct SipHasher24 {
 /// Although the SipHash algorithm is considered to be generally strong,
 /// it is not intended for cryptographic purposes. As such, all
 /// cryptographic uses of this implementation are _strongly discouraged_.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct SipHasher(SipHasher24);
 
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct Hasher<S: Sip> {
     k0: u64,
@@ -79,7 +79,7 @@ struct Hasher<S: Sip> {
     _marker: PhantomData<S>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct State {
     // v0, v2 and v1, v3 show up in pairs in the algorithm,
@@ -459,7 +459,7 @@ trait Sip {
     fn d_rounds(_: &mut State);
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 struct Sip13Rounds;
 
 impl Sip for Sip13Rounds {
@@ -476,7 +476,7 @@ impl Sip for Sip13Rounds {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 struct Sip24Rounds;
 
 impl Sip for Sip24Rounds {

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -18,7 +18,7 @@ use core::ptr;
 use core::slice;
 
 /// A 128-bit (2x64) hash output
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Hash128 {
     pub h1: u64,
@@ -41,14 +41,14 @@ impl Into<u128> for Hash128 {
 }
 
 /// An implementation of SipHash128 1-3.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher13 {
     hasher: Hasher<Sip13Rounds>,
 }
 
 /// An implementation of SipHash128 2-4.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher24 {
     hasher: Hasher<Sip24Rounds>,
@@ -64,10 +64,10 @@ pub struct SipHasher24 {
 /// Although the SipHash algorithm is considered to be generally strong,
 /// it is not intended for cryptographic purposes. As such, all
 /// cryptographic uses of this implementation are _strongly discouraged_.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct SipHasher(SipHasher24);
 
-#[derive(Debug, Copy, PartialEq)]
+#[derive(Debug, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct Hasher<S: Sip> {
     k0: u64,
@@ -79,7 +79,7 @@ struct Hasher<S: Sip> {
     _marker: PhantomData<S>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct State {
     // v0, v2 and v1, v3 show up in pairs in the algorithm,
@@ -459,7 +459,7 @@ trait Sip {
     fn d_rounds(_: &mut State);
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default)]
 struct Sip13Rounds;
 
 impl Sip for Sip13Rounds {
@@ -476,7 +476,7 @@ impl Sip for Sip13Rounds {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default)]
 struct Sip24Rounds;
 
 impl Sip for Sip24Rounds {

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -19,6 +19,7 @@ use core::slice;
 
 /// A 128-bit (2x64) hash output
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Hash128 {
     pub h1: u64,
     pub h2: u64,
@@ -41,12 +42,14 @@ impl Into<u128> for Hash128 {
 
 /// An implementation of SipHash128 1-3.
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher13 {
     hasher: Hasher<Sip13Rounds>,
 }
 
 /// An implementation of SipHash128 2-4.
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SipHasher24 {
     hasher: Hasher<Sip24Rounds>,
 }
@@ -65,6 +68,7 @@ pub struct SipHasher24 {
 pub struct SipHasher(SipHasher24);
 
 #[derive(Debug, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct Hasher<S: Sip> {
     k0: u64,
     k1: u64,
@@ -76,6 +80,7 @@ struct Hasher<S: Sip> {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct State {
     // v0, v2 and v1, v3 show up in pairs in the algorithm,
     // and simd implementations of SipHash will use vectors

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -320,3 +320,12 @@ fn test_hash_no_concat_alias() {
     assert_ne!(v, w);
     assert_ne!(hash(&v), hash(&w));
 }
+
+#[test]
+fn test_hash_serde() {
+    let val64 = 0xdeadbeef_deadbeef_u64;
+    let hash = hash(&val64);
+    let serialized = serde_json::to_string(&hash).unwrap();
+    let deserialized: u64 = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(hash, deserialized);
+}


### PR DESCRIPTION
To make the bloom filter serializable the siphash must also be serde aware.
This PR adds an optional feature "serde" that adds automatic derives. 
Currently, this works with the 64bit SipHash as this is used in the bloom filters.

No breaking changes, the version still needs to be increased and published to crates.io.
Other projects can use this by adding `siphasher = {version = "0.3.2", features = ["serde"] }` to `Cargo.toml`