### PR TITLE
Fix incorrect transformation between keys and slices of u8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/jedisct1/rust-siphash"
 homepage = "https://docs.rs/siphasher"
 documentation = "https://docs.rs/siphasher"
 readme = "README.md"
-version = "0.3.6"
+version = "0.3.7"
 categories = ["algorithms", "cryptography"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/jedisct1/rust-siphash"
 homepage = "https://docs.rs/siphasher"
 documentation = "https://docs.rs/siphasher"
 readme = "README.md"
-version = "0.3.5"
+version = "0.3.6"
 categories = ["algorithms", "cryptography"]
 edition = "2018"
 

--- a/src/sip.rs
+++ b/src/sip.rs
@@ -160,7 +160,7 @@ impl SipHasher {
         let mut b0 = [0u8; 8];
         let mut b1 = [0u8; 8];
         b0.copy_from_slice(&key[0..8]);
-        b1.copy_from_slice(&key[0..8]);
+        b1.copy_from_slice(&key[8..16]);
         let key0 = u64::from_le_bytes(b0);
         let key1 = u64::from_le_bytes(b1);
         Self::new_with_keys(key0, key1)
@@ -175,7 +175,7 @@ impl SipHasher {
     pub fn key(&self) -> [u8; 16] {
         let mut bytes = [0u8; 16];
         bytes[0..8].copy_from_slice(&self.0.hasher.k0.to_le_bytes());
-        bytes[0..16].copy_from_slice(&self.0.hasher.k1.to_le_bytes());
+        bytes[8..16].copy_from_slice(&self.0.hasher.k1.to_le_bytes());
         bytes
     }
 }
@@ -200,7 +200,7 @@ impl SipHasher13 {
         let mut b0 = [0u8; 8];
         let mut b1 = [0u8; 8];
         b0.copy_from_slice(&key[0..8]);
-        b1.copy_from_slice(&key[0..8]);
+        b1.copy_from_slice(&key[8..16]);
         let key0 = u64::from_le_bytes(b0);
         let key1 = u64::from_le_bytes(b1);
         Self::new_with_keys(key0, key1)
@@ -215,7 +215,7 @@ impl SipHasher13 {
     pub fn key(&self) -> [u8; 16] {
         let mut bytes = [0u8; 16];
         bytes[0..8].copy_from_slice(&self.hasher.k0.to_le_bytes());
-        bytes[0..16].copy_from_slice(&self.hasher.k1.to_le_bytes());
+        bytes[8..16].copy_from_slice(&self.hasher.k1.to_le_bytes());
         bytes
     }
 }
@@ -240,7 +240,7 @@ impl SipHasher24 {
         let mut b0 = [0u8; 8];
         let mut b1 = [0u8; 8];
         b0.copy_from_slice(&key[0..8]);
-        b1.copy_from_slice(&key[0..8]);
+        b1.copy_from_slice(&key[8..16]);
         let key0 = u64::from_le_bytes(b0);
         let key1 = u64::from_le_bytes(b1);
         Self::new_with_keys(key0, key1)
@@ -255,7 +255,7 @@ impl SipHasher24 {
     pub fn key(&self) -> [u8; 16] {
         let mut bytes = [0u8; 16];
         bytes[0..8].copy_from_slice(&self.hasher.k0.to_le_bytes());
-        bytes[0..16].copy_from_slice(&self.hasher.k1.to_le_bytes());
+        bytes[8..16].copy_from_slice(&self.hasher.k1.to_le_bytes());
         bytes
     }
 }

--- a/src/sip.rs
+++ b/src/sip.rs
@@ -154,9 +154,28 @@ impl SipHasher {
         SipHasher(SipHasher24::new_with_keys(key0, key1))
     }
 
+    /// Creates a `SipHasher` from a 16 byte key.
+    pub fn new_with_key(key: &[u8; 16]) -> SipHasher {
+        let mut b0 = [0u8; 8];
+        let mut b1 = [0u8; 8];
+        b0.copy_from_slice(&key[0..8]);
+        b1.copy_from_slice(&key[0..8]);
+        let key0 = u64::from_le_bytes(b0);
+        let key1 = u64::from_le_bytes(b1);
+        Self::new_with_keys(key0, key1)
+    }
+
     /// Get the keys used by this hasher
     pub fn keys(&self) -> (u64, u64) {
         (self.0.hasher.k0, self.0.hasher.k1)
+    }
+
+    /// Get the key used by this hasher as a 16 byte vector
+    pub fn key(&self) -> [u8; 16] {
+        let mut bytes = [0u8; 16];
+        bytes[0..8].copy_from_slice(&self.0.hasher.k0.to_le_bytes());
+        bytes[0..16].copy_from_slice(&self.0.hasher.k1.to_le_bytes());
+        bytes
     }
 }
 
@@ -175,9 +194,28 @@ impl SipHasher13 {
         }
     }
 
+    /// Creates a `SipHasher13` from a 16 byte key.
+    pub fn new_with_key(key: &[u8; 16]) -> SipHasher13 {
+        let mut b0 = [0u8; 8];
+        let mut b1 = [0u8; 8];
+        b0.copy_from_slice(&key[0..8]);
+        b1.copy_from_slice(&key[0..8]);
+        let key0 = u64::from_le_bytes(b0);
+        let key1 = u64::from_le_bytes(b1);
+        Self::new_with_keys(key0, key1)
+    }
+
     /// Get the keys used by this hasher
     pub fn keys(&self) -> (u64, u64) {
         (self.hasher.k0, self.hasher.k1)
+    }
+
+    /// Get the key used by this hasher as a 16 byte vector
+    pub fn key(&self) -> [u8; 16] {
+        let mut bytes = [0u8; 16];
+        bytes[0..8].copy_from_slice(&self.hasher.k0.to_le_bytes());
+        bytes[0..16].copy_from_slice(&self.hasher.k1.to_le_bytes());
+        bytes
     }
 }
 
@@ -196,9 +234,28 @@ impl SipHasher24 {
         }
     }
 
+    /// Creates a `SipHasher24` from a 16 byte key.
+    pub fn new_with_key(key: &[u8; 16]) -> SipHasher24 {
+        let mut b0 = [0u8; 8];
+        let mut b1 = [0u8; 8];
+        b0.copy_from_slice(&key[0..8]);
+        b1.copy_from_slice(&key[0..8]);
+        let key0 = u64::from_le_bytes(b0);
+        let key1 = u64::from_le_bytes(b1);
+        Self::new_with_keys(key0, key1)
+    }
+
     /// Get the keys used by this hasher
     pub fn keys(&self) -> (u64, u64) {
         (self.hasher.k0, self.hasher.k1)
+    }
+
+    /// Get the key used by this hasher as a 16 byte vector
+    pub fn key(&self) -> [u8; 16] {
+        let mut bytes = [0u8; 16];
+        bytes[0..8].copy_from_slice(&self.hasher.k0.to_le_bytes());
+        bytes[0..16].copy_from_slice(&self.hasher.k1.to_le_bytes());
+        bytes
     }
 }
 

--- a/src/sip.rs
+++ b/src/sip.rs
@@ -15,6 +15,7 @@ use core::hash;
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr;
+use core::u64;
 
 /// An implementation of SipHash 1-3.
 ///

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -181,7 +181,7 @@ impl SipHasher {
         let mut b0 = [0u8; 8];
         let mut b1 = [0u8; 8];
         b0.copy_from_slice(&key[0..8]);
-        b1.copy_from_slice(&key[0..8]);
+        b1.copy_from_slice(&key[8..16]);
         let key0 = u64::from_le_bytes(b0);
         let key1 = u64::from_le_bytes(b1);
         Self::new_with_keys(key0, key1)
@@ -196,7 +196,7 @@ impl SipHasher {
     pub fn key(&self) -> [u8; 16] {
         let mut bytes = [0u8; 16];
         bytes[0..8].copy_from_slice(&self.0.hasher.k0.to_le_bytes());
-        bytes[0..16].copy_from_slice(&self.0.hasher.k1.to_le_bytes());
+        bytes[8..16].copy_from_slice(&self.0.hasher.k1.to_le_bytes());
         bytes
     }
 }
@@ -229,7 +229,7 @@ impl SipHasher13 {
         let mut b0 = [0u8; 8];
         let mut b1 = [0u8; 8];
         b0.copy_from_slice(&key[0..8]);
-        b1.copy_from_slice(&key[0..8]);
+        b1.copy_from_slice(&key[8..16]);
         let key0 = u64::from_le_bytes(b0);
         let key1 = u64::from_le_bytes(b1);
         Self::new_with_keys(key0, key1)
@@ -244,7 +244,7 @@ impl SipHasher13 {
     pub fn key(&self) -> [u8; 16] {
         let mut bytes = [0u8; 16];
         bytes[0..8].copy_from_slice(&self.hasher.k0.to_le_bytes());
-        bytes[0..16].copy_from_slice(&self.hasher.k1.to_le_bytes());
+        bytes[8..16].copy_from_slice(&self.hasher.k1.to_le_bytes());
         bytes
     }
 }
@@ -277,7 +277,7 @@ impl SipHasher24 {
         let mut b0 = [0u8; 8];
         let mut b1 = [0u8; 8];
         b0.copy_from_slice(&key[0..8]);
-        b1.copy_from_slice(&key[0..8]);
+        b1.copy_from_slice(&key[8..16]);
         let key0 = u64::from_le_bytes(b0);
         let key1 = u64::from_le_bytes(b1);
         Self::new_with_keys(key0, key1)
@@ -292,7 +292,7 @@ impl SipHasher24 {
     pub fn key(&self) -> [u8; 16] {
         let mut bytes = [0u8; 16];
         bytes[0..8].copy_from_slice(&self.hasher.k0.to_le_bytes());
-        bytes[0..16].copy_from_slice(&self.hasher.k1.to_le_bytes());
+        bytes[8..16].copy_from_slice(&self.hasher.k1.to_le_bytes());
         bytes
     }
 }

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -15,6 +15,7 @@ use core::hash;
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr;
+use core::u64;
 
 /// A 128-bit (2x64) hash output
 #[derive(Debug, Clone, Copy, Default)]

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -175,9 +175,28 @@ impl SipHasher {
         SipHasher(SipHasher24::new_with_keys(key0, key1))
     }
 
+    /// Creates a `SipHasher` from a 16 byte key.
+    pub fn new_with_key(key: &[u8; 16]) -> SipHasher {
+        let mut b0 = [0u8; 8];
+        let mut b1 = [0u8; 8];
+        b0.copy_from_slice(&key[0..8]);
+        b1.copy_from_slice(&key[0..8]);
+        let key0 = u64::from_le_bytes(b0);
+        let key1 = u64::from_le_bytes(b1);
+        Self::new_with_keys(key0, key1)
+    }
+
     /// Get the keys used by this hasher
     pub fn keys(&self) -> (u64, u64) {
         (self.0.hasher.k0, self.0.hasher.k1)
+    }
+
+    /// Get the key used by this hasher as a 16 byte vector
+    pub fn key(&self) -> [u8; 16] {
+        let mut bytes = [0u8; 16];
+        bytes[0..8].copy_from_slice(&self.0.hasher.k0.to_le_bytes());
+        bytes[0..16].copy_from_slice(&self.0.hasher.k1.to_le_bytes());
+        bytes
     }
 }
 
@@ -204,9 +223,28 @@ impl SipHasher13 {
         }
     }
 
+    /// Creates a `SipHasher13` from a 16 byte key.
+    pub fn new_with_key(key: &[u8; 16]) -> SipHasher13 {
+        let mut b0 = [0u8; 8];
+        let mut b1 = [0u8; 8];
+        b0.copy_from_slice(&key[0..8]);
+        b1.copy_from_slice(&key[0..8]);
+        let key0 = u64::from_le_bytes(b0);
+        let key1 = u64::from_le_bytes(b1);
+        Self::new_with_keys(key0, key1)
+    }
+
     /// Get the keys used by this hasher
     pub fn keys(&self) -> (u64, u64) {
         (self.hasher.k0, self.hasher.k1)
+    }
+
+    /// Get the key used by this hasher as a 16 byte vector
+    pub fn key(&self) -> [u8; 16] {
+        let mut bytes = [0u8; 16];
+        bytes[0..8].copy_from_slice(&self.hasher.k0.to_le_bytes());
+        bytes[0..16].copy_from_slice(&self.hasher.k1.to_le_bytes());
+        bytes
     }
 }
 
@@ -233,9 +271,28 @@ impl SipHasher24 {
         }
     }
 
+    /// Creates a `SipHasher24` from a 16 byte key.
+    pub fn new_with_key(key: &[u8; 16]) -> SipHasher24 {
+        let mut b0 = [0u8; 8];
+        let mut b1 = [0u8; 8];
+        b0.copy_from_slice(&key[0..8]);
+        b1.copy_from_slice(&key[0..8]);
+        let key0 = u64::from_le_bytes(b0);
+        let key1 = u64::from_le_bytes(b1);
+        Self::new_with_keys(key0, key1)
+    }
+
     /// Get the keys used by this hasher
     pub fn keys(&self) -> (u64, u64) {
         (self.hasher.k0, self.hasher.k1)
+    }
+
+    /// Get the key used by this hasher as a 16 byte vector
+    pub fn key(&self) -> [u8; 16] {
+        let mut bytes = [0u8; 16];
+        bytes[0..8].copy_from_slice(&self.hasher.k0.to_le_bytes());
+        bytes[0..16].copy_from_slice(&self.hasher.k1.to_le_bytes());
+        bytes
     }
 }
 


### PR DESCRIPTION
The implementations of `new_with_key` and `key` for *all* variants of SipHasher contain critical security bugs: `new_with_key` initializes both keys from the first 64 bits of the given key and ignores the second 64 bits, and `key` copies k0 to the first 64 bits of the output and then immediately overwrites it with k1.

While I'm not a cryptography expert, I can confidently state that this *significantly* weakens the algorithm.