### PR TITLE
Added mem dbg and fixed how no-std is defined

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ opt-level = 3
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
-mem_dbg = { version = "0.2.2", optional = true }
+mem_dbg = { version = "0.2.4", optional = true }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,14 @@ opt-level = 3
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
+mem_dbg = { version = "0.2.2", optional = true }
 
 [features]
 default = ["std"]
 serde_std = ["std", "serde/std"]
 serde_no_std = ["serde/alloc"]
+mem_dbg = [
+    "dep:mem_dbg",
+    "std",
+]
 std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::cast_lossless)]
 #![allow(clippy::many_single_char_names)]

--- a/src/sip.rs
+++ b/src/sip.rs
@@ -23,6 +23,7 @@ use core::u64;
 /// See: <https://www.aumasson.jp/siphash/siphash.pdf>
 #[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct SipHasher13 {
     hasher: Hasher<Sip13Rounds>,
 }
@@ -32,6 +33,7 @@ pub struct SipHasher13 {
 /// See: <https://www.aumasson.jp/siphash/siphash.pdf>
 #[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct SipHasher24 {
     hasher: Hasher<Sip24Rounds>,
 }
@@ -50,10 +52,12 @@ pub struct SipHasher24 {
 /// cryptographic uses of this implementation are _strongly discouraged_.
 #[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct SipHasher(SipHasher24);
 
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 struct Hasher<S: Sip> {
     k0: u64,
     k1: u64,
@@ -66,6 +70,7 @@ struct Hasher<S: Sip> {
 
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 struct State {
     // v0, v2 and v1, v3 show up in pairs in the algorithm,
     // and simd implementations of SipHash will use vectors
@@ -558,6 +563,7 @@ trait Sip {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 struct Sip13Rounds;
 
 impl Sip for Sip13Rounds {
@@ -575,6 +581,7 @@ impl Sip for Sip13Rounds {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 struct Sip24Rounds;
 
 impl Sip for Sip24Rounds {

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -21,6 +21,7 @@ use core::u64;
 /// A 128-bit (2x64) hash output
 #[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct Hash128 {
     pub h1: u64,
     pub h2: u64,
@@ -44,6 +45,7 @@ impl From<Hash128> for u128 {
 /// An implementation of SipHash128 1-3.
 #[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct SipHasher13 {
     hasher: Hasher<Sip13Rounds>,
 }
@@ -51,6 +53,7 @@ pub struct SipHasher13 {
 /// An implementation of SipHash128 2-4.
 #[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct SipHasher24 {
     hasher: Hasher<Sip24Rounds>,
 }
@@ -66,10 +69,12 @@ pub struct SipHasher24 {
 /// it is not intended for cryptographic purposes. As such, all
 /// cryptographic uses of this implementation are _strongly discouraged_.
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct SipHasher(SipHasher24);
 
 #[derive(Debug, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 struct Hasher<S: Sip> {
     k0: u64,
     k1: u64,
@@ -82,6 +87,7 @@ struct Hasher<S: Sip> {
 
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 struct State {
     // v0, v2 and v1, v3 show up in pairs in the algorithm,
     // and simd implementations of SipHash will use vectors
@@ -630,6 +636,7 @@ trait Sip {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 struct Sip13Rounds;
 
 impl Sip for Sip13Rounds {
@@ -647,6 +654,7 @@ impl Sip for Sip13Rounds {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 struct Sip24Rounds;
 
 impl Sip for Sip24Rounds {


### PR DESCRIPTION
I have added support as an optional feature to [mem-dbg](https://crates.io/crates/mem_dbg), a crate to accurately measure the size of structs. I need to measure the sizes of crates using `siphash` as part of their structs, hence the need for this pull request.

Plus, previously you had defined the no-std attribute as:

```rust
#![cfg_attr(not(test), no_std)]
```

But that way, if you requested the std feature, it would not actually disable `no-std` - It would only do that while testing. In order to do both I changed it to:

```rust
#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
```

Cheers!